### PR TITLE
Add: Implementación de estado "Sobredosis"

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,11 +3,11 @@
 ## Tareas del proyecto
 - [x] Cambiar el Nombre del Plugin a UN_Drugs para evitar confusiones
 - [x] Hacer que el objeto de la droga sea stakeble hasta 64
-- [ ] Arreglar bug del consumo del LSD que deja llamarada en el suelo
+- [x] Arreglar bug del consumo del LSD que deja llamarada en el suelo
 - [x] Al usar el comando /drugs de forma correcta salir en el chat un mensaje en el juego 
 - [x] Al usar el comando /drugs de forma incorrecta salir en el chat un mensaje en el juego
 - [x] Al consumir alguna sustancia agregar aviso solo visible para el jugador, ejemplo: Has consumido marihuana
-- [ ] Si se consumen 2 sustancias de diferente tipo mientras siguen los efectos de alguna se produce una sobredosis,
+- [x] Si se consumen 2 sustancias de diferente tipo mientras siguen los efectos de alguna se produce una sobredosis,
 es decir el jugador pierde todos sus efectos y adquiere estos 2 nuevos: Lentitud y el efecto del whiter que reduce corazones durante 30 segundos
 - [x] Añadir droga Hongos, efectos: Lentitud 2, Mareo 3, Resistencia 5.
 - [ ] Añadir permisos exclusivos al comando /drugs para que solo admins puedan usarlo

--- a/src/main/java/events/DrugsEvent.java
+++ b/src/main/java/events/DrugsEvent.java
@@ -11,46 +11,65 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.potion.PotionEffectType;
 import org.bukkit.scheduler.BukkitRunnable;
 import unmineraft.undrugs.UNDrugs;
 import unmineraft.undrugs.consumable.Drugs;
 
-import java.util.LinkedList;
-import java.util.Objects;
-import java.util.UUID;
+import java.util.*;
 
 public class DrugsEvent implements Listener {
     private static UNDrugs plugin;
 
     private static final LinkedList<ItemMeta> isConsumable = new LinkedList<>();
     private static final LinkedList<UUID> itemCooldown = new LinkedList<>();
+    
+    private boolean isDifferentDrugEffectActive(Player player, String itemConsumed){
+        LinkedList<PotionEffect> activeEffects = (LinkedList<PotionEffect>) player.getActivePotionEffects();
+
+        if (activeEffects != Drugs.drugsInformation.get(itemConsumed).get("effects")) return true;
+        return false;
+    }
 
 
     /* La creacion de objetos toma de base objetos ya existentes, por ende si el objeto base no es consumible
      * es necesaria la simulacion de dicha caracteristica a traves de esta funcion */
     private void startEffects(Player player, ItemStack item){
         LinkedList<PotionEffect> itemEffects = null;
+        String drugConsumed = "";
         // Si el jugador consume Marihuana
         if (Objects.equals(item.getItemMeta(), Drugs.marihuana.getItemMeta())){
-            itemEffects = (LinkedList<PotionEffect>) Drugs.drugsInformation.get("Marihuana").get("effects");
+            drugConsumed = "Marihuana";
         }
 
         // Si el jugador consume Perico
         if (Objects.equals(item.getItemMeta(), Drugs.perico.getItemMeta())){
-            itemEffects = (LinkedList<PotionEffect>) Drugs.drugsInformation.get("Perico").get("effects");
+            drugConsumed = "Perico";
         }
 
         // Si el jugador consume LSD
         if (Objects.equals(item.getItemMeta(), Drugs.LSD.getItemMeta())){
-            itemEffects = (LinkedList<PotionEffect>) Drugs.drugsInformation.get("LSD").get("effects");
+            drugConsumed = "LSD";
         }
 
         // Si el jugador consume Hongos
         if (Objects.equals(item.getItemMeta(), Drugs.hongos.getItemMeta())) {
-            itemEffects = (LinkedList<PotionEffect>) Drugs.drugsInformation.get("Hongos").get("effects");
+            drugConsumed = "Hongos";
         }
 
-        if (itemEffects != null) player.addPotionEffects(itemEffects);
+        if (!isDifferentDrugEffectActive(player, drugConsumed)){
+            itemEffects = (LinkedList<PotionEffect>) Drugs.drugsInformation.get(drugConsumed).get("effects");
+            player.addPotionEffects(itemEffects);
+            return;
+        }
+
+        if (isDifferentDrugEffectActive(player, drugConsumed)){
+            // Se limpia cada efecto del jugador, y se implementan los efectos de la "sobredosis"
+            for (PotionEffect effect : player.getActivePotionEffects()){
+                player.removePotionEffect(effect.getType());
+            }
+            player.addPotionEffects(Drugs.sobredosis);
+        }
     }
 
     @EventHandler

--- a/src/main/java/unmineraft/undrugs/consumable/Drugs.java
+++ b/src/main/java/unmineraft/undrugs/consumable/Drugs.java
@@ -18,11 +18,11 @@ import java.util.*;
 
 /*
  * Para nuevos items es necesario incluirlos en el archivo de configuracion
- * y en el arreglo de pathDruds, con el mismo nombre que posee en la configuracion
+ * y en el arreglo de pathDrugs, con el mismo nombre que posee en la configuracion
  */
 
 public class Drugs {
-    private static String generalPath = "Config.Drugs"; // Ruta de los items en el archivo de configuracion
+    private static final String generalPath = "Config.Drugs"; // Ruta de los items en el archivo de configuracion
     private static List<String> generalLore; // Descripcion que comparten todos los items
     private static FileConfiguration config; // Archivo de configuracion
 
@@ -52,13 +52,14 @@ public class Drugs {
     public static ItemStack LSD;
     public static ItemStack hongos;
 
+    public static LinkedList<PotionEffect> sobredosis;
+
     // Permite obtener la lista del archivo de configuracion que se muestran como descripcion de cada item
     private static void updateGeneralLore(String path){
         try {
-            List<String> lore = Objects.requireNonNull(config.getStringList(path));
-            generalLore = lore;
+            generalLore = Objects.requireNonNull(config.getStringList(path));
         } catch (Error error){
-            generalLore = Arrays.asList(new String[]{""});
+            generalLore = Collections.singletonList("");
         }
     }
 
@@ -232,5 +233,8 @@ public class Drugs {
         Drugs.perico = createItem("Perico");
         Drugs.LSD = createItem("LSD");
         Drugs.hongos = createItem("Hongos");
+
+        String pathSobredosis = generalPath + ".Sobredosis";
+        Drugs.sobredosis = getEffects(pathSobredosis + ".Effects", getDuration(pathSobredosis + ".Duration"));
     }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -7,13 +7,35 @@ Config:
       - "&r&5Este item es &c&lILEGAL&r&5, que no te atrapen con el"
       - ""
       - "&5Su consumo otorga: &8%effectsDrug%"
-    # Para el manejo de los efectos es necesario:
-    # 1. Al agregar efectos a un item ya existente es necesario que este, sea ingresado
-    #    teniendo en cuenta su referencia en el juego (https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html)
-    #    en mayusculas, siguiendo la estructura:
-      #   - EFECTO;NIVEL_DEL_EFECTO
-    # 2. Una vez registrado el efecto debe incluirlo en el apartado de Label_Effects, para que este sea mostrado
-    #    en el cliente de manera correcta
+      # Para el manejo de los efectos es necesario:
+      # 1. Los tipos de efectos están disponibles en esta doc: (https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/potion/PotionEffectType.html)
+      #    Deben ser registrados tal cual aparecen en la página con la estructura de:
+      #       - EFECTO;NIVEL_DEL_EFECTO
+      # 2. Una vez registrado el efecto debe incluir la descripción qué ira en el lore del item, para que este sea mostrado
+      #    en el cliente de manera correcta
+      # 3. Crear una variable que almacene el nuevo item en la clase Drugs (Archivo: Drugs.java), con la estructura:
+      #       - public static ItemStack NOMBRE_NUEVO_ITEM_VARIABLE;
+      # 4. Registrar el nombre con el cual se describe el objeto en este documento, en la variable pathDrugs de la clase Drugs (Archivo: Drugs.java)
+      #       - public static String[] pathDrugs = {"Marihuana", "Perico", "LSD", "Hongos", "NOMBRE_NUEVO_ITEM_CONFIGURACION", ...}
+      # 5. Dirigirse a la función "buildDrugs" en la clase Drugs (Archivo: Drugs.java) y a la variable creada en el paso #3
+      #    almacenar el resultado de la función "createItem("NOMBRE_NUEVO_ITEM_CONFIGURACION")" quedando como:
+      #       - Drugs.NOMBRE_NUEVO_ITEM_VARIABLE = createItem(NOMBRE_NUEVO_ITEM_CONFIGURACION);
+      # 6. Para que al ser consumido los efectos carguen es necesario ir al administrador de eventos (Archivo: DrugsEvent.java),
+      #    en la función DrugsEvent debe incluir el meta del objeto a la lista, a través del código:
+      #       - isConsumable.add(Drugs.NOMBRE_NUEVO_ITEM_VARIABLE.getItemMeta())
+      # 7. En la función startEffects de la clase DrugsEvent (Archivo: DrugsEvent.java) debe copiar el código:
+      #       - if (Objects.equals(item.getItemMeta(), Drugs.NOMBRE_NUEVO_ITEM_VARIABLE.getItemMeta())) {
+      #             drugConsumed = .NOMBRE_NUEVO_ITEM_CONFIGURACION;
+      #         }
+      # 8. Agregar esta condición en la función onCommand (Archivo: DrugsCommand) en el apartado de:
+      #       - else if (message.equalsIgnoreCase(NOMBRE_DE_LA_DROGA)){
+      #            selectedItem = Drugs.NOMBRE_NUEVO_ITEM_VARIABLE;
+      #         }
+      #   Antes del código que luce:
+      #       - else {
+      #            player.sendMessage(this.plugin.name + ChatColor.DARK_PURPLE + "Elemento solicitado no reconocido");
+      #            return false;
+      #         }
     Marihuana:
       DisplayName: "&r&2Marihuana"
       BaseItem: BEETROOT

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -64,3 +64,8 @@ Config:
       existAdditionalLore: false
       additionalLore:
         - ""
+    Sobredosis:
+      Duration: 30
+      Effects:
+        - WITHER;1
+        - SLOW;1


### PR DESCRIPTION
- Si el jugador está bajo los efectos de un ítem y consume otro tipo de droga, este pierde todos los efectos activos y entra en estado de sobredosis
- El jugador recibe un mensaje de advertencia sobre la mezcla de sustancias cuando el efecto es activado
- Efectos externos (como los que otorga la manzana encantada) no activan el efecto a menos de que posean la misma configuración de la última droga consumida por el jugador
- El archivo de configuración tiene una guía de como implementar nuevos ítems