### PR TITLE
Fix: Crafteo marihuana permitido con remolacha

### DIFF
--- a/src/main/java/events/BaseItemBreakEvent.java
+++ b/src/main/java/events/BaseItemBreakEvent.java
@@ -59,7 +59,7 @@ public class BaseItemBreakEvent implements Listener {
                     int randomNum = getRandomNumber(1, 4);
                     item.setAmount(randomNum);
 
-                    // Drop del cogote
+                    // Drop del item base
                     player.getWorld().dropItem(player.getLocation(), item);
                     player.sendMessage(plugin.name + ChatColor.WHITE + "Haz recolectado " + randomNum + " nuevas unidades");
 

--- a/src/main/java/events/BaseItemBreakEvent.java
+++ b/src/main/java/events/BaseItemBreakEvent.java
@@ -71,6 +71,7 @@ public class BaseItemBreakEvent implements Listener {
                         // Si el jugador ya tiene el item, sumamos al stack los que acaba de "cultivar"
                         if (playerInventory.contains(item.getType())){
                             int slot = playerInventory.first(item.getType());
+
                             ItemStack savedItem = playerInventory.getItem(slot);
 
                             if (savedItem == null) return;
@@ -99,6 +100,10 @@ public class BaseItemBreakEvent implements Listener {
                             player.getInventory().setItem(indexFirstEmpty, item);
                         }
                         player.sendMessage(plugin.name + ChatColor.WHITE + "Haz recolectado " + randomNum + " nuevas unidades");
+
+                        // Drop de semillas
+                        ItemStack seeds = new ItemStack(Material.BEETROOT_SEEDS, getRandomNumber(0, 2));
+                        player.getWorld().dropItem(player.getLocation(), seeds);
                     }
                 }
             }.run();

--- a/src/main/java/events/BaseItemBreakEvent.java
+++ b/src/main/java/events/BaseItemBreakEvent.java
@@ -10,7 +10,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.inventory.PlayerInventory;
 import org.bukkit.scheduler.BukkitRunnable;
 import unmineraft.undrugs.UNDrugs;
 import unmineraft.undrugs.craftBase.BaseItemCraft;
@@ -55,57 +54,19 @@ public class BaseItemBreakEvent implements Listener {
             new BukkitRunnable(){
                 @Override
                 public void run(){
-                    int indexFirstEmpty = player.getInventory().firstEmpty();
-
                     ItemStack item = mapBlockDropItem.get(block.getType());
-                    PlayerInventory playerInventory = player.getInventory();
-
-                    // Si no hay espacio ni un stack disponible
-                    if (indexFirstEmpty == -1 && !(playerInventory.contains(item.getType()))){
-                        player.sendMessage(plugin.name + ChatColor.WHITE + "Inventario Lleno");
-                        return;
-                    }
 
                     int randomNum = getRandomNumber(1, 4);
-                    if (mapBlockDropItem.containsKey(block.getType())){
-                        // Si el jugador ya tiene el item, sumamos al stack los que acaba de "cultivar"
-                        if (playerInventory.contains(item.getType())){
-                            int slot = playerInventory.first(item.getType());
+                    item.setAmount(randomNum);
 
-                            ItemStack savedItem = playerInventory.getItem(slot);
+                    // Drop del cogote
+                    player.getWorld().dropItem(player.getLocation(), item);
+                    player.sendMessage(plugin.name + ChatColor.WHITE + "Haz recolectado " + randomNum + " nuevas unidades");
 
-                            if (savedItem == null) return;
-
-                            // Obtenemos el tamaño del stack
-                            int stack = savedItem.getAmount();
-
-                            // Si el stack está lleno creamos otro
-                            if (stack == 64){
-                                item.setAmount(randomNum);
-                                System.out.println(randomNum);
-
-                                // Si no tiene espacio disponible en el stack y no tiene mas espacio no se entrega el item
-                                if (indexFirstEmpty == -1){
-                                    player.sendMessage(plugin.name + ChatColor.WHITE + "Inventario Lleno");
-                                    return;
-                                }
-                                playerInventory.setItem(indexFirstEmpty, item);
-                            } else {
-                                savedItem.setAmount(stack + randomNum);
-                                playerInventory.setItem(slot, savedItem);
-                            }
-
-                        } else {
-                            item.setAmount(randomNum);
-                            player.getInventory().setItem(indexFirstEmpty, item);
-                        }
-                        player.sendMessage(plugin.name + ChatColor.WHITE + "Haz recolectado " + randomNum + " nuevas unidades");
-
-                        // Drop de semillas
-                        ItemStack seeds = new ItemStack(Material.BEETROOT_SEEDS, getRandomNumber(0, 2));
-                        player.getWorld().dropItem(player.getLocation(), seeds);
+                    // Drop de semillas
+                    ItemStack seeds = new ItemStack(Material.BEETROOT_SEEDS, getRandomNumber(0, 2));
+                    player.getWorld().dropItem(player.getLocation(), seeds);
                     }
-                }
             }.run();
         }
     }

--- a/src/main/java/events/CraftDrugEvent.java
+++ b/src/main/java/events/CraftDrugEvent.java
@@ -1,0 +1,60 @@
+package events;
+
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.CraftingInventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import unmineraft.undrugs.UNDrugs;
+import unmineraft.undrugs.consumable.Drugs;
+import unmineraft.undrugs.craftBase.BaseItemCraft;
+
+import java.util.Objects;
+
+public class CraftDrugEvent implements Listener {
+    private static UNDrugs plugin;
+
+    @EventHandler
+    public void onPrepareItemCraft(PrepareItemCraftEvent event){
+        if (event.getInventory().getResult() == null) return;
+
+
+        // Manejo del cogote como elemento válido para la marihuana
+        if (event.getInventory().getResult().getType() == Drugs.marihuana.getType()){
+            CraftingInventory inventoryCraft = event.getInventory();
+
+            ItemStack[] items = inventoryCraft.getMatrix();
+
+            int[] positions = {3, 4, 5};
+            boolean isValidBeetroot = true;
+
+            /*
+             * El cogote de manera forzosa debe estar en el medio, asi que evaluamos
+             * todas las posiciones posibles, si el item es del mismo tipo, pero no
+             * tiene el mismo meta, se asume que no es el cogote y por ende es inválido
+             */
+            for (int pos : positions){
+                if (items[pos] != null) {
+                    if (items[pos].getType() == BaseItemCraft.cogote.getType()) {
+                        // Verificamos que los display names sean iguales
+                        String itemDisplayName = Objects.requireNonNull(items[pos].getItemMeta()).getDisplayName();
+                        String cogoteDisplayName = Objects.requireNonNull(BaseItemCraft.cogote.getItemMeta()).getDisplayName();
+
+                        if (!(itemDisplayName.equals(cogoteDisplayName))) isValidBeetroot = false;
+                    }
+                }
+            }
+
+            // Si no es válido, no generara la marihuana
+            if (!isValidBeetroot){
+                event.getInventory().setResult(new ItemStack(Material.AIR));
+            }
+        }
+    }
+
+    public CraftDrugEvent(UNDrugs plugin){
+        CraftDrugEvent.plugin = plugin;
+    }
+}

--- a/src/main/java/unmineraft/undrugs/UNDrugs.java
+++ b/src/main/java/unmineraft/undrugs/UNDrugs.java
@@ -4,6 +4,7 @@ import commands.BaseItemCraftCommand;
 import commands.DrugsCommand;
 import commands.UnDrugsCommands;
 import events.BaseItemBreakEvent;
+import events.CraftDrugEvent;
 import events.DrugsEvent;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
@@ -55,6 +56,7 @@ public final class UNDrugs extends JavaPlugin {
         PluginManager pluginManager = getServer().getPluginManager();
         pluginManager.registerEvents(new DrugsEvent(this), this);
         pluginManager.registerEvents(new BaseItemBreakEvent(this), this);
+        pluginManager.registerEvents(new CraftDrugEvent(this), this);
     }
 
     public void configRegister(){


### PR DESCRIPTION
Se quitan algunas responsabilidades al plugin buscando minimizar los errores, adicionalmente se verifica el crafteo para evitar que ítems base iguales permitan adquirir los ítems con elementos diferentes a los deseados